### PR TITLE
are we using an incorrect update function?

### DIFF
--- a/pkg/operator/encryption/helpers_test.go
+++ b/pkg/operator/encryption/helpers_test.go
@@ -53,14 +53,14 @@ func createEncryptionKeySecretWithKeyFromExistingSecret(targetNS string, gr sche
 	return secret
 }
 
-func createDummyKubeAPIPod(name, namespace string) *corev1.Pod {
+func createDummyKubeAPIPod(name, namespace, revision string) *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 			Labels: map[string]string{
 				"apiserver": "true",
-				"revision":  "1",
+				"revision":  revision,
 			},
 		},
 		Status: corev1.PodStatus{

--- a/pkg/operator/encryption/pod_state_controller_encryption_test.go
+++ b/pkg/operator/encryption/pod_state_controller_encryption_test.go
@@ -44,7 +44,7 @@ func TestEncryptionPodStateController(t *testing.T) {
 				schema.GroupResource{Group: "", Resource: "secrets"}: true,
 			},
 			initialResources: []runtime.Object{
-				createDummyKubeAPIPod("kube-apiserver-1", "kms"),
+				createDummyKubeAPIPod("kube-apiserver-1", "kms", "1"),
 			},
 			initialSecrets: []*corev1.Secret{
 				createEncryptionKeySecretWithRawKey("kms", schema.GroupResource{"", "secrets"}, 1, []byte("61def964fb967f5d7c44a2af8dab6865")),
@@ -76,6 +76,20 @@ func TestEncryptionPodStateController(t *testing.T) {
 				if !wasSecretValidated {
 					ts.Errorf("the secret wasn't updated and validated")
 				}
+			},
+		},
+
+		// scenario 2: imitates API servers being converging onto a single revision
+		{
+			name:            "checks if PodStateNotConverged condition is set - atm it panics",
+			targetNamespace: "kms",
+			destName:        "encryption-config-kube-apiserver-test",
+			targetGRs: map[schema.GroupResource]bool{
+				schema.GroupResource{Group: "", Resource: "secrets"}: true,
+			},
+			initialResources: []runtime.Object{
+				createDummyKubeAPIPod("kube-apiserver-1", "kms", "1"),
+				createDummyKubeAPIPod("kube-apiserver-2", "kms", "2"),
 			},
 		},
 	}

--- a/pkg/operator/encryption/state_controller_encryption_test.go
+++ b/pkg/operator/encryption/state_controller_encryption_test.go
@@ -44,7 +44,7 @@ func TestEncryptionStateController(t *testing.T) {
 				schema.GroupResource{Group: "", Resource: "secrets"}: true,
 			},
 			initialResources: []runtime.Object{
-				createDummyKubeAPIPod("kube-apiserver-1", "kms"),
+				createDummyKubeAPIPod("kube-apiserver-1", "kms", "1"),
 			},
 			expectedActions: []string{"list:pods:kms", "list:secrets:openshift-config-managed"},
 		},
@@ -60,7 +60,7 @@ func TestEncryptionStateController(t *testing.T) {
 				schema.GroupResource{Group: "", Resource: "secrets"}: true,
 			},
 			initialResources: []runtime.Object{
-				createDummyKubeAPIPod("kube-apiserver-1", "kms"),
+				createDummyKubeAPIPod("kube-apiserver-1", "kms", "1"),
 				createEncryptionKeySecretWithRawKey("kms", schema.GroupResource{"", "secrets"}, 1, []byte("61def964fb967f5d7c44a2af8dab6865")),
 			},
 			expectedActions:       []string{"list:pods:kms", "list:secrets:openshift-config-managed", "get:secrets:openshift-config-managed", "create:secrets:openshift-config-managed", "create:events:kms"},


### PR DESCRIPTION
At the moment the new test panics because we use `UpdateStatus` function which is not implemented in the fake client. 

In general, the encryption controllers use `GetStaticPodOperatorState` to get the state of the operator and accept `StaticPodOperatorClient` as a primary interface. That makes me think that we should use `UpdateStaticPodStatus` instead of [`UpdateStatus`](https://github.com/enj/cluster-kube-apiserver-operator/blob/enj/f/enc_config/pkg/operator/encryption/pod_state_controller_encryption.go#L107), wdyt?